### PR TITLE
[d.ts] Supports multi in update

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -330,12 +330,12 @@ declare module "monk" {
     update(
       query: FilterQuery<T>,
       update: UpdateQuery<T> | Partial<T>,
-      options?: UpdateOneOptions
+      options?: UpdateOneOptions & { multi?: boolean },
     ): Promise<UpdateWriteOpResult>;
     update(
       query: FilterQuery<T>,
       update: UpdateQuery<T> | Partial<T>,
-      options: UpdateOneOptions,
+      options: UpdateOneOptions & { multi?: boolean },
       callback: Callback<UpdateWriteOpResult>
     ): void;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ declare module "monk" {
   type FindOptions = FindOneOptions & { rawCursor?: boolean };
   type RemoveOptions = CommonOptions & SingleMulti;
   type StatsOptions = { scale: number; session?: ClientSession };
+  type UpdateOptions = UpdateOneOptions & { multi?: boolean; single?: boolean; replaceOne?: boolean; }
 
   // Returns
   type DropResult = "ns not found" | true;
@@ -330,12 +331,12 @@ declare module "monk" {
     update(
       query: FilterQuery<T>,
       update: UpdateQuery<T> | Partial<T>,
-      options?: UpdateOneOptions & { multi?: boolean },
+      options?: UpdateOptions,
     ): Promise<UpdateWriteOpResult>;
     update(
       query: FilterQuery<T>,
       update: UpdateQuery<T> | Partial<T>,
-      options: UpdateOneOptions & { multi?: boolean },
+      options: UpdateOptions,
       callback: Callback<UpdateWriteOpResult>
     ): void;
   }


### PR DESCRIPTION
Fix d.ts
Supports multi in update.
Additionaly, also suppots monk specific options (single, repaceOne).

Reference:
https://automattic.github.io/monk/docs/collection/update.html
https://github.com/automattic/monk/blob/c2714365978b448454b729dbf97e61fadb4cbef8/lib/collection.js#L375-L391