### PR TITLE
[d.ts] Fix createIndex

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,11 +36,11 @@ declare module "monk" {
 
   // Inputs
   type SingleMulti = { single?: boolean; multi?: boolean };
-  type CreateIndexInput<T> = string | { [key in keyof T]?: 1 | -1 };
+  type CreateIndexInput<T> = TFields | { [key in keyof T]?: 1 | -1 };
   type CollectionInsertOneOptionsMonk = CollectionInsertOneOptions & {
     castIds: boolean;
   };
-  type DropIndexInput<T> = CreateIndexInput<T> & string[];
+  type DropIndexInput<T> = CreateIndexInput<T>;
   type DropIndexOptions = CommonOptions & { maxTimeMS?: number };
   type FindOptions = FindOneOptions & { rawCursor?: boolean };
   type RemoveOptions = CommonOptions & SingleMulti;


### PR DESCRIPTION
Fix d.ts

Missing `createIndex(Array<string>)` in v7.3.1

In https://github.com/Automattic/monk/commit/a3e587706e3c1edc6997932745c995677fdee1b9
Before
```ts
type TFields = string | Array<string>;

  fields?: TFields | { [key: string]: 1 | -1 },
```

After
```ts
type TFields = string | Array<string>;
type CreateIndexInput<T> = string | { [key in keyof T]?: 1 | -1 };

  fields: CreateIndexInput<T>,
```

So, fixing this.
